### PR TITLE
Blind output with user-provided offsets

### DIFF
--- a/cosmosis/output/output_base.py
+++ b/cosmosis/output/output_base.py
@@ -136,6 +136,13 @@ class OutputBase(metaclass=OutputMetaclass):
         if not self.begun_sampling:
             self._begun_sampling(params)
             self.begun_sampling=True
+
+        #Blind output by applying offsets
+        if self.apply_blinding_offsets:
+            if len(self._blinding_offsets)!=len(params):
+                raise ValueError("Length of blinding offsets %d does not match number of output parameters %d"%(len(self._blinding_offsets), len(params)))
+            params+= self._blinding_offsets
+
         #Pass to the subclasses to write output
         self._write_parameters(params)
 

--- a/cosmosis/output/text_output.py
+++ b/cosmosis/output/text_output.py
@@ -13,9 +13,12 @@ class TextColumnOutput(OutputBase):
     FILE_EXTENSION = ".txt"
     _aliases = ["text", "txt"]
 
-    def __init__(self, filename, rank=0, nchain=1, delimiter='\t', lock=True, resume=False):
+    def __init__(self, filename, rank=0, nchain=1, delimiter='\t', lock=True, resume=False,
+                 apply_blinding_offsets=False, blinding_offset_file=None):
         super(TextColumnOutput, self).__init__()
         self.delimiter = delimiter
+
+        self.apply_blinding_offsets = apply_blinding_offsets
 
         #If filename already ends in .txt then remove it for a moment
         if filename.endswith(self.FILE_EXTENSION):
@@ -46,6 +49,8 @@ class TextColumnOutput(OutputBase):
                 print("Note: You set resume=T but the file {} does not exist so I will start a new one".format(self._filename))
             self._file = open(self._filename, "w")
             self.resumed = False
+        if apply_blinding_offsets:
+            self._blinding_offsets = np.load(blinding_offset_file)
         if lock:
             try:
                 self.lock_file(self._file)
@@ -143,8 +148,14 @@ In the last case you can set lock=F in the [output] section to disable this feat
         delimiter = options.get('delimiter', '\t')
         rank = options.get('rank', 0)
         nchain = options.get('parallel', 1)
+        apply_blinding_offsets = utils.boolean_string(options.get('apply_blinding_offsets', False))
+        print("apply_blinding_offsets", type(apply_blinding_offsets), apply_blinding_offsets)
+        blinding_offset_file = options.get('blinding_offsets', None)
+        if apply_blinding_offsets & (blinding_offset_file is None):
+            raise RuntimeError("You set apply_blinding_offsets but did not provide blinding_offset_file")
         lock = utils.boolean_string(options.get('lock', True))
-        return cls(filename, rank, nchain, delimiter=delimiter, lock=lock, resume=resume)
+        return cls(filename, rank, nchain, delimiter=delimiter, lock=lock, resume=resume,
+                   apply_blinding_offsets=apply_blinding_offsets, blinding_offset_file=blinding_offset_file)
 
     @classmethod
     def load_from_options(cls, options):


### PR DESCRIPTION
Let the user provide a set of parameter offsets for the purpose of blinding the output. This makes looking at the chains safe!

This is activated by setting `apply_blinding_offsets = True` in the `[output]` section of the parameter file. The offsets are saved as a .npy file. Add `blinding_offsets = /path/to/file` to the parameter file.

Caveat: The user must set the offsets corresponding to output columns such as `prior like post weight` to 0 manually.

The modification is mostly copied from @MCostanzi. It is tested for the emcee and multinest samplers.