### PR TITLE
Fix libcosmosis.so install name on macOS

### DIFF
--- a/cosmosis/config/compilers.mk
+++ b/cosmosis/config/compilers.mk
@@ -8,28 +8,13 @@ else
   COMMON_FLAGS=-O3 -g -fPIC
 endif
 
-COMMON_C_FLAGS=$(COMMON_FLAGS) -I${COSMOSIS_SRC_DIR}/
-OS=$(shell uname -s)
-PEDANTIC_C_FLAGS=-Wall -Wextra -pedantic
-CXXFLAGS=$(COMMON_C_FLAGS) $(USER_CXXFLAGS) -std=c++14 
-CFLAGS=$(COMMON_C_FLAGS) -std=c99 $(USER_CFLAGS)
-FFLAGS=$(COMMON_FLAGS) -I${COSMOSIS_SRC_DIR}/datablock -std=gnu -ffree-line-length-none $(USER_FFLAGS)
-LDFLAGS=$(USER_LDFLAGS) -L${COSMOSIS_SRC_DIR}/datablock -Wl,-rpath,$(COSMOSIS_SRC_DIR)/datablock
-PYTHON=python
-MAKEFLAGS += --print-directory
-
-ifeq (1,$(COSMOSIS_DEBUG))
-LDFLAGS+=
-endif
-
-
 # Might be using 
 ifeq (1,${COSMOSIS_OMP})
 	ifeq (, $(COSMOSIS_OMP_FLAGS))
 		COMMON_FLAGS+=$(COSMOSIS_OMP_FLAGS)
 		LDFLAGS+=$(COSMOSIS_OMP_LDFLAGS)
 	else ifeq (Darwin, $(OS))
-		COMMON_FLAGS+= -fopenmp
+		COMMON_FLAGS+= Xpreprocessor -fopenmp
 		LDFLAGS+= -lomp
 	else
 		COMMON_FLAGS+= -fopenmp
@@ -37,11 +22,22 @@ ifeq (1,${COSMOSIS_OMP})
 	endif
 endif
 
+
+COMMON_C_FLAGS=$(COMMON_FLAGS) -I${COSMOSIS_SRC_DIR}/
+OS=$(shell uname -s)
+PEDANTIC_C_FLAGS=-Wall -Wextra -pedantic
+CXXFLAGS=$(COMMON_C_FLAGS) $(USER_CXXFLAGS) -std=c++14 
+CFLAGS=$(COMMON_C_FLAGS) -std=c99 $(USER_CFLAGS)
+FFLAGS=$(COMMON_FLAGS) -I${COSMOSIS_SRC_DIR}/datablock -std=gnu -ffree-line-length-none $(USER_FFLAGS)
+#LDFLAGS=$(USER_LDFLAGS) -L${COSMOSIS_SRC_DIR}/datablock -Wl,-rpath,$(COSMOSIS_SRC_DIR)/datablock
+LDFLAGS=$(USER_LDFLAGS) -L${COSMOSIS_SRC_DIR}/datablock
+PYTHON=python
+MAKEFLAGS += --print-directory
+
+ifeq (1,$(COSMOSIS_DEBUG))
+LDFLAGS+=
+endif
+
 ifeq (Darwin, $(OS))
   LDFLAGS+=-headerpad_max_install_names
 endif
-
-
-# CXXFLAGS+= -isystem ${CONDA_PREFIX}/include 
-# CFLAGS+= -isystem ${CONDA_PREFIX}/include
-# LDFLAGS+= -L${CONDA_PREFIX}/lib

--- a/cosmosis/configure.py
+++ b/cosmosis/configure.py
@@ -50,10 +50,13 @@ def generate_commands(cosmosis_src_dir, debug=False, omp=True, brew=False, brew_
 
     commands = [
         f"export COSMOSIS_SRC_DIR=\"{cosmosis_src_dir}\"",
-        "export LIBRARY_PATH=$LIBRARY_PATH:$COSMOSIS_SRC_DIR/datablock",
-        "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$COSMOSIS_SRC_DIR/datablock",
-        "export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$COSMOSIS_SRC_DIR/datablock",
         "export COSMOSIS_ALT_COMPILERS=1",
+    ]
+
+    if not brew:
+        commands += [
+            "export LIBRARY_PATH=$LIBRARY_PATH:$COSMOSIS_SRC_DIR/datablock",
+            "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$COSMOSIS_SRC_DIR/datablock",
     ]
 
     if brew:

--- a/cosmosis/datablock/Makefile
+++ b/cosmosis/datablock/Makefile
@@ -47,7 +47,7 @@ names: section_names.txt generate_sections.py
 
 
 libcosmosis.so: datablock.o entry.o section.o c_datablock.o datablock_logging.o cosmosis_section_names.o cosmosis_types.o cosmosis_wrappers.o cosmosis_modules.o handler.o
-	$(CXX) $(LDFLAGS) -shared -o $(CURDIR)/$@ $+ -lgfortran
+	$(CXX) $(LDFLAGS) -shared $(RPATH) -o $(CURDIR)/$@ $+ -lgfortran
 
 %.o: %.F90
 	$(FC) $(FFLAGS) -c  -o $(CURDIR)/$@ $+


### PR DESCRIPTION
This commits changes the linking of libcosmosis.so on macOS to use `@rpath` in the install name, rather than the full path to the library. This avoids having to reset it with `install_name_tool` after installation.