### PR TITLE
Change to bash-friendly configure program

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - os: ubuntu-latest
             INSTALL_DEPS: sudo apt-get update && sudo apt-get -y install gfortran-7 swig libopenmpi-dev openmpi-bin libopenblas-dev && sudo ln -s `which gfortran-7` /usr/local/bin/gfortran
           - os: macos-latest
-            INSTALL_DEPS: brew update && brew install gcc swig libomp open-mpi openblas
+            INSTALL_DEPS: brew update && brew install gcc swig libomp open-mpi openblas && if [ ! -f /usr/local/bin/gfortran ]; then ln -s /usr/local/bin/gfortran-$(brew list --versions gcc | awk '{print $2}' | cut -d. -f1) /usr/local/bin/gfortran; fi
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/cosmosis/configure.py
+++ b/cosmosis/configure.py
@@ -103,6 +103,5 @@ def generate_commands(cosmosis_src_dir, debug=False, omp=True, brew=False, brew_
 if __name__ == '__main__':
     args = parser.parse_args()
     cmds = generate_commands(args.source, debug=args.debug, omp=args.omp, conda=args.conda, brew=args.brew or args.brew_gcc, brew_gcc=args.brew_gcc)
-    for command in cmds:
-        print(command)
+    print("; ".join(cmds))
 


### PR DESCRIPTION
The current configure program, `cosmosis-configure`, can fail on some bash versions because it is sent a multi-line string from `cosmosis/configure.py`, which does not work correctly - the later lines don't see the changes made in the first line.

This puts them all in a single statement with semi-colon separators.