### PR TITLE
Vector extras

### DIFF
--- a/cosmosis/runtime/pipeline.py
+++ b/cosmosis/runtime/pipeline.py
@@ -896,7 +896,7 @@ class LikelihoodPipeline(Pipeline):
         for section,name in self.extra_saves:
             if ('#' in name):
                 n,l = name.split('#')
-                for i in range(l):
+                for i in range(int(l)):
                     extra_names.append('{}--{}_{}'.format(section,n,i))
             else:
                 extra_names.append('%s--%s'%(section,name))

--- a/cosmosis/test/test_module4.py
+++ b/cosmosis/test/test_module4.py
@@ -5,5 +5,5 @@ def setup(options):
 
 def execute(block, config):
     p3 = block['parameters', 'p3']
-    # do nothing execpt read
+    # do nothing except read
     return 0

--- a/cosmosis/test/test_module4.py
+++ b/cosmosis/test/test_module4.py
@@ -5,5 +5,5 @@ def setup(options):
 
 def execute(block, config):
     p3 = block['parameters', 'p3']
-    # do nothing execpt read
+    # do nothing execpt read
     return 0


### PR DESCRIPTION
There was a bug in the code that lets you save a vector quantity as a set of columns in the output file. This should fix it.
Thanks to Shiming Gu for reporting.