### PR TITLE
Enable zeus patience for small nsteps

### DIFF
--- a/cosmosis/samplers/zeus/zeus_sampler.py
+++ b/cosmosis/samplers/zeus/zeus_sampler.py
@@ -228,6 +228,8 @@ class ZeusSampler(ParallelSampler):
 
         # Main execution
         self.sampler.run(self.p0, self.nsteps)
+        # Update patience (relevant when self.nsteps<self.patience)
+        self.sampler.patience-= self.nsteps
         # record ending point of this iteration
         end = self.sampler.chain.shape[0]
 


### PR DESCRIPTION
This PR fixes a subtle bug in the way zeus is run. So far, when `patience` is set to a value larger than `nsteps`, the sampler cannot run more iterations than `patience` at a time, by design. Therefore, tuning might never end. This is fixed by subtracting the number of past iterations from patience after the sampler is run.