### PR TITLE
Allow new parameters to be added using the -v flag

### DIFF
--- a/cosmosis/runtime/parameter.py
+++ b/cosmosis/runtime/parameter.py
@@ -247,6 +247,17 @@ class Parameter(object):
             parameters.append(Parameter(section, name,
                                         start, limits, pri))
 
+        # Allow parameters not originally specified in the parameter
+        # file to be added on the command line
+        if override is not None:
+            for (section, name) in override:
+                if (section, name) not in parameters:
+                    value = override[(section,name)]
+                    start, limits = Parameter.parse_parameter(value)
+                    pri = priors_data.get((section, name), None)
+                    parameters.append(Parameter(section, name,
+                                            start, limits, pri))
+
         return parameters
 
 

--- a/cosmosis/test/test_parameters.py
+++ b/cosmosis/test/test_parameters.py
@@ -1,0 +1,57 @@
+from ..runtime import parameter
+import numpy as np
+import tempfile
+
+
+def test_override_new():
+    with tempfile.NamedTemporaryFile('w') as values:
+        values.write(
+            "[parameters]\n"
+            "p1=-3.0  0.0  3.0\n"
+            "p2=-3.0  0.0  3.0\n"
+            "p3=20.0\n")
+        values.flush()
+        print(values.name)
+        params = parameter.Parameter.load_parameters(values.name, override=None)
+
+    assert params[0] == ("parameters", "p1")
+    assert params[0].start == 0.0
+    assert np.allclose(params[0].limits, [-3, 3])
+
+    assert params[1] == ("parameters", "p2")
+    assert params[1].start == 0.0
+
+    assert params[2] == ("parameters", "p3")
+    assert np.isclose(params[2].start, 20.0)
+
+
+    with tempfile.NamedTemporaryFile('w') as values:
+        values.write(
+            "[parameters]\n"
+            "p1=-3.0  0.0  3.0\n"
+            "p2=-3.0  0.0  3.0\n"
+            "p3=20.0\n")
+        values.flush()
+        override = {
+            ("parameters", "p1"): "1.0",
+            ("xxx", "aaa"): "100.0",
+        }
+        params = parameter.Parameter.load_parameters(values.name, override=override)
+    
+
+    assert params[0] == ("parameters", "p1")
+    assert params[0].start == 1.0
+    assert np.allclose(params[0].limits, 1.0)
+
+    assert params[1] == ("parameters", "p2")
+    assert params[1].start == 0.0
+    assert np.allclose(params[1].limits, [-3, 3])
+
+    assert params[2] == ("parameters", "p3")
+    assert np.isclose(params[2].start, 20.0)
+
+    print(params)
+    assert params[3] == ("xxx", "aaa")
+    assert np.isclose(params[3].start, 100.0)
+    assert np.allclose(params[3].limits, 100.0)
+


### PR DESCRIPTION
Previously the -v flag could only modify existing parameters. This allows it to add new ones as well.