### PR TITLE
Fix OpenMP flags in compilers.mk

### DIFF
--- a/cosmosis/config/compilers.mk
+++ b/cosmosis/config/compilers.mk
@@ -10,7 +10,7 @@ endif
 
 # Might be using 
 ifeq (1,${COSMOSIS_OMP})
-	ifeq (, $(COSMOSIS_OMP_FLAGS))
+	ifneq (, $(COSMOSIS_OMP_FLAGS))
 		COMMON_FLAGS+=$(COSMOSIS_OMP_FLAGS)
 		LDFLAGS+=$(COSMOSIS_OMP_LDFLAGS)
 	else ifeq (Darwin, $(OS))
@@ -22,7 +22,6 @@ ifeq (1,${COSMOSIS_OMP})
 	endif
 endif
 
-
 COMMON_C_FLAGS=$(COMMON_FLAGS) -I${COSMOSIS_SRC_DIR}/
 OS=$(shell uname -s)
 PEDANTIC_C_FLAGS=-Wall -Wextra -pedantic
@@ -30,7 +29,7 @@ CXXFLAGS=$(COMMON_C_FLAGS) $(USER_CXXFLAGS) -std=c++14
 CFLAGS=$(COMMON_C_FLAGS) -std=c99 $(USER_CFLAGS)
 FFLAGS=$(COMMON_FLAGS) -I${COSMOSIS_SRC_DIR}/datablock -std=gnu -ffree-line-length-none $(USER_FFLAGS)
 #LDFLAGS=$(USER_LDFLAGS) -L${COSMOSIS_SRC_DIR}/datablock -Wl,-rpath,$(COSMOSIS_SRC_DIR)/datablock
-LDFLAGS=$(USER_LDFLAGS) -L${COSMOSIS_SRC_DIR}/datablock
+LDFLAGS+=$(USER_LDFLAGS) -L${COSMOSIS_SRC_DIR}/datablock
 PYTHON=python
 MAKEFLAGS += --print-directory
 


### PR DESCRIPTION
This fixes OpenMP flags not being set correctly.
