### PR TITLE
Implement nautilus sampler interface

### DIFF
--- a/cosmosis/postprocessing/postprocess.py
+++ b/cosmosis/postprocessing/postprocess.py
@@ -316,6 +316,8 @@ class DynestyProcessor(MultinestProcessor):
 		col = self.get_col(name)
 		return col
 
+class NautilusProcess(DynestyProcessor):
+	sampler = "nautilus"
 
 
 class PMCPostProcessor(WeightedMetropolisProcessor):

--- a/cosmosis/postprocessing/statistics.py
+++ b/cosmosis/postprocessing/statistics.py
@@ -709,10 +709,13 @@ class MultinestStatistics(WeightedStatistics, MultinestPostProcessorElement, Met
         # which is just read from the file
         files = super(MultinestStatistics,self).run()
         logz = self.source.final_metadata[0]["log_z"]
-        logz_sigma = self.source.final_metadata[0]["log_z_error"]
+        try:
+            logz_sigma = self.source.final_metadata[0]["log_z_error"]
+        except KeyError:
+            logz_sigma = "(error not computed)"
         #First print to screen
         print("Bayesian evidence:")
-        print("    log(Z) = %g ± %g" % (logz,logz_sigma))
+        print(f"    log(Z) = {logz:.2f} ± {logz_sigma}")
         print()
 
 
@@ -725,7 +728,7 @@ class MultinestStatistics(WeightedStatistics, MultinestPostProcessorElement, Met
         #Now save to file
         header = '#logz    logz_sigma'
         f, filename, new_file  = self.get_text_output("evidence", header, self.source.name)
-        f.write('%e    %e\n'%(logz,logz_sigma))
+        f.write(f'{logz}    {logz_sigma}\n')
 
         #Include evidence in list of created files
         files.append(filename)

--- a/cosmosis/samplers/__init__.py
+++ b/cosmosis/samplers/__init__.py
@@ -23,3 +23,4 @@ from .apriori.apriori_sampler import AprioriSampler
 from .dynesty.dynesty_sampler import DynestySampler
 from .zeus.zeus_sampler import ZeusSampler
 from .poco.poco_sampler import PocoSampler
+from .nautilus.nautilus_sampler import NautilusSampler

--- a/cosmosis/samplers/multinest/multinest_sampler.py
+++ b/cosmosis/samplers/multinest/multinest_sampler.py
@@ -64,6 +64,7 @@ class MultinestSampler(ParallelSampler):
     parallel_output = False
     sampler_outputs = [("prior", float), ("like", float), ("post", float), ("weight", float)]
     supports_smp=False
+    internal_resume = True
 
     def config(self):
         if self.pool:

--- a/cosmosis/samplers/nautilus/nautilus_sampler.py
+++ b/cosmosis/samplers/nautilus/nautilus_sampler.py
@@ -1,0 +1,70 @@
+from .. import ParallelSampler
+import numpy as np
+import sys
+
+
+def log_probability_function(p):
+    return pipeline.posterior(p)[0]
+
+def prior_transform(p):
+    return pipeline.denormalize_vector_from_prior(p)
+
+class NautilusSampler(ParallelSampler):
+    parallel_output = False
+    sampler_outputs = [('log_weight', float), ("like", float)]
+
+    def config(self):
+        global pipeline
+        pipeline = self.pipeline
+
+        if self.is_master():
+            self.n_live = self.read_ini("n_live", int, 1500)
+            #self.n_update = self.read_ini("n_update", int, None)
+            #self.enlarge = self.read_ini("enlarge", float, None)
+            self.n_batch = self.read_ini("n_batch", int, 100)
+            #self.random_state = self.read_ini("random_state", int, None)
+            #self.filepath = self.read_ini("filepath", str, None)
+            self.resume = self.read_ini("resume", bool, True)
+            self.f_live = self.read_ini("f_live", float, 0.01)
+            #self.n_shell = self.read_ini("n_shell", float, None)
+            self.n_eff = self.read_ini("n_eff", float, 10000.0)
+            self.discard_exploration = self.read_ini("discard_exploration", bool, False)
+            self.verbose = self.read_ini("verbose", bool, False)
+
+        self.converged = False
+
+    def execute(self):
+        from nautilus import Sampler
+
+        n_dim = self.pipeline.nvaried
+
+        sampler = Sampler(
+            prior_transform, 
+            log_probability_function,
+            n_dim, 
+            n_live = self.n_live,
+            #n_update = self.n_update,
+            #enlarge = self.enlarge,
+            n_batch = self.n_batch,
+            #random_state = self.random_state,
+            #filepath = self.filepath,
+            resume = self.resume,
+            pool = self.pool
+            )
+
+        sampler.run(f_live=self.f_live,
+                    #n_shell=self.n_shell,
+                    n_eff=self.n_eff,
+                    discard_exploration=self.discard_exploration,
+                    verbose=self.verbose)
+
+        for sample, logwt, logl in zip(*sampler.posterior()):
+            self.output.parameters(sample, logwt, logl)
+
+        self.output.final("efficiency", sampler.effective_sample_size() / sampler.n_like)
+        self.output.final("nsample", len(sampler.posterior()[0]))
+        self.output.final("log_z", sampler.evidence())
+        self.converged = True
+
+    def is_converged(self):
+        return self.converged

--- a/cosmosis/samplers/nautilus/nautilus_sampler.py
+++ b/cosmosis/samplers/nautilus/nautilus_sampler.py
@@ -6,8 +6,10 @@ import sys
 def log_probability_function(p):
     return pipeline.posterior(p)[0]
 
+
 def prior_transform(p):
     return pipeline.denormalize_vector_from_prior(p)
+
 
 class NautilusSampler(ParallelSampler):
     parallel_output = False
@@ -19,16 +21,22 @@ class NautilusSampler(ParallelSampler):
 
         if self.is_master():
             self.n_live = self.read_ini("n_live", int, 1500)
-            #self.n_update = self.read_ini("n_update", int, None)
-            #self.enlarge = self.read_ini("enlarge", float, None)
+            self.n_update = self.read_ini("n_update", int, self.n_live)
+            self.enlarge = self.read_ini(
+                "enlarge", float, 1.1**self.pipeline.nvaried)
             self.n_batch = self.read_ini("n_batch", int, 100)
-            #self.random_state = self.read_ini("random_state", int, None)
-            #self.filepath = self.read_ini("filepath", str, None)
+            self.random_state = self.read_ini("random_state", int, -1)
+            if self.random_state < 0:
+                self.random_state = None
+            self.filepath = self.read_ini("filepath", str, 'None')
+            if self.filepath.lower() == 'none':
+                self.filepath = None
             self.resume = self.read_ini("resume", bool, True)
             self.f_live = self.read_ini("f_live", float, 0.01)
-            #self.n_shell = self.read_ini("n_shell", float, None)
+            self.n_shell = self.read_ini("n_shell", int, self.n_batch)
             self.n_eff = self.read_ini("n_eff", float, 10000.0)
-            self.discard_exploration = self.read_ini("discard_exploration", bool, False)
+            self.discard_exploration = self.read_ini(
+                "discard_exploration", bool, False)
             self.verbose = self.read_ini("verbose", bool, False)
 
         self.converged = False
@@ -39,21 +47,21 @@ class NautilusSampler(ParallelSampler):
         n_dim = self.pipeline.nvaried
 
         sampler = Sampler(
-            prior_transform, 
+            prior_transform,
             log_probability_function,
-            n_dim, 
-            n_live = self.n_live,
-            #n_update = self.n_update,
-            #enlarge = self.enlarge,
-            n_batch = self.n_batch,
-            #random_state = self.random_state,
-            #filepath = self.filepath,
-            resume = self.resume,
-            pool = self.pool
-            )
+            n_dim,
+            n_live=self.n_live,
+            n_update=self.n_update,
+            enlarge=self.enlarge,
+            n_batch=self.n_batch,
+            random_state=self.random_state,
+            filepath=self.filepath,
+            resume=self.resume,
+            pool=self.pool
+        )
 
         sampler.run(f_live=self.f_live,
-                    #n_shell=self.n_shell,
+                    n_shell=self.n_shell,
                     n_eff=self.n_eff,
                     discard_exploration=self.discard_exploration,
                     verbose=self.verbose)
@@ -61,7 +69,8 @@ class NautilusSampler(ParallelSampler):
         for sample, logwt, logl in zip(*sampler.posterior()):
             self.output.parameters(sample, logwt, logl)
 
-        self.output.final("efficiency", sampler.effective_sample_size() / sampler.n_like)
+        self.output.final(
+            "efficiency", sampler.effective_sample_size() / sampler.n_like)
         self.output.final("nsample", len(sampler.posterior()[0]))
         self.output.final("log_z", sampler.evidence())
         self.converged = True

--- a/cosmosis/samplers/nautilus/sampler.yaml
+++ b/cosmosis/samplers/nautilus/sampler.yaml
@@ -1,0 +1,35 @@
+name: "nautilus"
+version: "0.4.1"
+parallel: parallel
+purpose: "Neural Network-Boosted Importance Nested Sampling"
+url: "https://github.com/johannesulf/nautilus"
+attribution: ["Johannes U. Lange"]
+
+explanation: >
+    Nautilus is an MIT-licensed pure-Python package for Bayesian posterior and
+    evidence estimation. It utilizes importance sampling and efficient space
+    exploration using neural networks. Compared to traditional MCMC and Nested
+    Sampling codes, it often needs fewer likelihood calls and produces much
+    larger posterior samples. Additionally, nautilus is highly accurate and
+    can produce Bayesian evidence estimates with percent precision.
+
+
+installation: >
+    pip install nautilus-sampler
+    conda install -c conda-forge nautilus-sampler
+    
+
+# List of configuration options for this sampler
+params:
+    n_live: (integer; default=1500) number of live points
+    n_update: (integer; default=n_live) number of additions to the live set before a new bound is created
+    enlarge: (float; default=1.1*n_dim) factor by which the volume of ellipsoidal bounds is increased
+    n_batch: (integer; default=100) number of likelihood evaluations that are performed at each step
+    random_state: (int; default=-1) random seed, negative values give a random random seed
+    filepath: (string; default='None') file used for checkpointing, must have .hdf5 ending
+    resume: (bool; default=True) if True, resume from previous run stored in `filepath`
+    f_live: (float; default=0.01) live set evidence fraction when exploration phase terminates
+    n_shell: (int; default=n_batch) minimum number of points in each shell
+    n_eff: (float; default=10000.0) minimum effective sample size
+    discard_exploration: (bool; default=False) whether to discard points drawn in the exploration phase
+    verbose: (bool; default=False) If true, print information about sampler progress

--- a/cosmosis/samplers/polychord/polychord_sampler.py
+++ b/cosmosis/samplers/polychord/polychord_sampler.py
@@ -79,6 +79,7 @@ class PolychordSampler(ParallelSampler):
     parallel_output = False
     sampler_outputs = [("prior", float), ("like", float), ("post", float), ("weight", float)]
     supports_smp=False
+    internal_resume = True
     understands_fast_subspaces = True
 
     def config(self):

--- a/cosmosis/samplers/sampler.py
+++ b/cosmosis/samplers/sampler.py
@@ -36,6 +36,7 @@ class Sampler(metaclass=RegisteredSampler):
     parallel_output = False
     is_parallel_sampler = False
     supports_resume = False
+    internal_resume = False
 
     
     def __init__(self, ini, pipeline, output=None):

--- a/cosmosis/test/test_samplers.py
+++ b/cosmosis/test/test_samplers.py
@@ -138,6 +138,9 @@ def test_polychord():
 def test_snake():
         run('snake', True)
 
+def test_nautilus():
+    run('nautilus', True)
+
 def test_star():
         run('star', False)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ mpi4py
 dulwich
 urllib3
 scikit-learn
+nautilus-sampler

--- a/setup.py
+++ b/setup.py
@@ -183,6 +183,7 @@ requirements = [
     "emcee",
     "dynesty",
     "zeus-mcmc",
+    "nautilus-mcmc",
     "dulwich",
     "scikit-learn",
     "future",

--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,7 @@ requirements = [
     "emcee",
     "dynesty",
     "zeus-mcmc",
-    "nautilus-mcmc",
+    "nautilus-sampler",
     "dulwich",
     "scikit-learn",
     "future",


### PR DESCRIPTION
This PR adds the nautilus sampler (https://nautilus-sampler.readthedocs.io/). I could need some help ensuring that everything works as expected.

* blobs: Nautilus supports blobs. The interface is very similar to emcee's. But I still need to figure out how to give those results back to CosmoSIS.
* MPI: Nautilus supports MPI parallelization via schwimmbad or any pool with a `map` method, just like emcee and dynesty. Seeing how dynesty and emcee are interfaced, MPI parallelization may already work. But that needs to be tested.
* tests: No unit tests have been implemented yet.