### PR TITLE
Bugfix for list sampler with vector quantities as extra output

### DIFF
--- a/cosmosis/samplers/list/list_sampler.py
+++ b/cosmosis/samplers/list/list_sampler.py
@@ -39,8 +39,13 @@ class ListSampler(ParallelSampler):
                 if self.output is not None:
                     self.output.add_column(str(p), float)
             if self.output is not None:
-                for p in self.pipeline.extra_saves:
-                    self.output.add_column('{}--{}'.format(*p), float)
+                for section,name in self.pipeline.extra_saves:
+                    if ('#' in name):
+                        n,l = name.split('#')
+                        for i in range(int(l)):
+                            self.output.add_column('{}--{}_{}'.format(section,n,i), float)
+                    else:
+                        self.output.add_column('%s--%s'%(section,name), float)
                 for p,ptype in self.sampler_outputs:
                     self.output.add_column(p, ptype)
 


### PR DESCRIPTION
Hi,

I've encountered a bug in the list sampler when I asked for vector quantities as additional outputs. Basically, the sampler didn't set up the correct number of extra columns in the output file.
This pull request fixes this issue by reusing some pieces of code from the output_names function defined in pipeline.py.

Best,
Benjamin