### PR TITLE
Updated nautilus integration

### DIFF
--- a/cosmosis/samplers/nautilus/nautilus_sampler.py
+++ b/cosmosis/samplers/nautilus/nautilus_sampler.py
@@ -44,7 +44,7 @@ class NautilusSampler(ParallelSampler):
             self.seed = self.read_ini("seed", int, -1)
             if self.seed < 0:
                 self.seed = None
-            self.resume_ = self.read_ini("resume", bool, True)
+            self.resume_ = self.read_ini("resume", bool, False)
             self.f_live = self.read_ini("f_live", float, 0.01)
             self.n_shell = self.read_ini("n_shell", int, self.n_batch)
             self.n_eff = self.read_ini("n_eff", float, 10000.0)

--- a/cosmosis/samplers/nautilus/nautilus_sampler.py
+++ b/cosmosis/samplers/nautilus/nautilus_sampler.py
@@ -32,7 +32,7 @@ class NautilusSampler(ParallelSampler):
         pipeline = self.pipeline
 
         if self.is_master():
-            self.n_live = self.read_ini("n_live", int, 1500)
+            self.n_live = self.read_ini("n_live", int, 2000)
             self.n_update = self.read_ini("n_update", int, self.n_live)
             self.enlarge_per_dim = self.read_ini("enlarge_per_dim", float, 1.1)
             self.n_points_min = self.read_ini("n_points_min", int,
@@ -40,12 +40,11 @@ class NautilusSampler(ParallelSampler):
             self.split_threshold = self.read_ini("split_threshold", float,
                                                  100.0)
             self.n_networks = self.read_ini("n_networks", int, 4)
-            self.n_jobs = self.read_ini("n_jobs", int, 1)
             self.n_batch = self.read_ini("n_batch", int, 100)
             self.seed = self.read_ini("seed", int, -1)
             if self.seed < 0:
                 self.seed = None
-            self.resume_ = self.read_ini("resume", bool, False)
+            self.resume_ = self.read_ini("resume", bool, True)
             self.f_live = self.read_ini("f_live", float, 0.01)
             self.n_shell = self.read_ini("n_shell", int, self.n_batch)
             self.n_eff = self.read_ini("n_eff", float, 10000.0)
@@ -80,7 +79,6 @@ class NautilusSampler(ParallelSampler):
             n_points_min=self.n_points_min,
             split_threshold=self.split_threshold,
             n_networks=self.n_networks,
-            n_jobs=self.n_jobs,
             n_batch=self.n_batch,
             seed=self.seed,
             filepath=resume_filepath,

--- a/cosmosis/samplers/nautilus/sampler.yaml
+++ b/cosmosis/samplers/nautilus/sampler.yaml
@@ -1,9 +1,11 @@
 name: "nautilus"
-version: "0.4.1"
+version: "0.7.0"
 parallel: parallel
 purpose: "Neural Network-Boosted Importance Nested Sampling"
 url: "https://github.com/johannesulf/nautilus"
 attribution: ["Johannes U. Lange"]
+cite:
+    - "https://arxiv.org/abs/2306.16923"
 
 explanation: >
     Nautilus is an MIT-licensed pure-Python package for Bayesian posterior and
@@ -21,10 +23,14 @@ installation: >
 
 # List of configuration options for this sampler
 params:
-    n_live: (integer; default=1500) number of live points
+    n_live: (integer; default=2000) number of live points
     n_update: (integer; default=n_live) number of additions to the live set before a new bound is created
-    enlarge: (float; default=1.1*n_dim) factor by which the volume of ellipsoidal bounds is increased
+    enlarge_per_dim: (float; default=1.1) factor by which ellipsoidal bounds are increased in each dimension
+    n_points_min: (integer; default=50+n_dim) minimum number of points for constructing a bounding ellipsoid
+    split_threshold: (float; default=100) volume threshold for splitting bounding ellipsoids
+    n_networks: (integer; default=4) number of neural networks in each network ensemble
     n_batch: (integer; default=100) number of likelihood evaluations that are performed at each step
+    seed: (integer, default=-1) random seed, no fixed seed is used if negative
     random_state: (int; default=-1) random seed, negative values give a random random seed
     filepath: (string; default='None') file used for checkpointing, must have .hdf5 ending
     resume: (bool; default=True) if True, resume from previous run stored in `filepath`

--- a/cosmosis/samplers/nautilus/sampler.yaml
+++ b/cosmosis/samplers/nautilus/sampler.yaml
@@ -33,7 +33,7 @@ params:
     seed: (integer, default=-1) random seed, no fixed seed is used if negative
     random_state: (int; default=-1) random seed, negative values give a random random seed
     filepath: (string; default='None') file used for checkpointing, must have .hdf5 ending
-    resume: (bool; default=True) if True, resume from previous run stored in `filepath`
+    resume: (bool; default=False) if True, resume from previous run stored in `filepath`
     f_live: (float; default=0.01) live set evidence fraction when exploration phase terminates
     n_shell: (int; default=n_batch) minimum number of points in each shell
     n_eff: (float; default=10000.0) minimum effective sample size


### PR DESCRIPTION
This PR updates the interface for the nautilus sampler. The `n_jobs` argument has been removed. Parallelization pools are now the same for likelihood evaluations and internal sampler calculations (training networks and sampling points). The default number of live points has been increased to 2000, reflecting the new nautilus default. Finally, the sampler documentation has been expanded, including adding the link to the nautilus paper.