### PR TITLE
Defer expanding environment variables in parent campaign runs so children can override

### DIFF
--- a/cosmosis/campaign.py
+++ b/cosmosis/campaign.py
@@ -459,7 +459,8 @@ def build_run(name, run_info, runs, components, output_dir, submission_info, out
 def expand_environment_variables(runs):
     """
     For each run, expand any environment variables in the all three parameter files.
-    We expand environment variables in the options, section names, and values.
+
+    Environment variables are only supported in values, not in keys or sections.
 
     Parameters
     ----------
@@ -473,23 +474,12 @@ def expand_environment_variables(runs):
             # We apply this to all the different ini files
             for ini in [run["params"], run["values"], run["priors"]]:
                 for section in ini.sections():
-                    # I've never seen anyone set a section name with an environment
-                    # variable but I guess it could happen
-                    new_section = os.path.expandvars(section)
-
-                    # If the section has changed we have to set the new name.
-                    # We could delete the old one but there shouldn't be a need to.
-                    # I guess it might neaten the metadata output.
-                    if new_section != section and not ini.has_section(new_section):
-                        ini.add_section(new_section)
-
                     # Now we can expand all the actual options
                     for option in ini.options(section):
-                        new_option = os.path.expandvars(option)
                         value = ini.get(section, option)
                         new_value = os.path.expandvars(value)
-                        if (new_value != value) or (new_option != option) or (new_section != section):
-                            ini.set(new_section, new_option, new_value)
+                        if new_value != value:
+                            ini.set(section, option, new_value)
 
 def parse_yaml_run_file(run_config):
     """

--- a/cosmosis/runtime/config.py
+++ b/cosmosis/runtime/config.py
@@ -31,7 +31,8 @@ class IncludingConfigParser(configparser.ConfigParser):
     comments, but still delineate sections).
     """
 
-    def __init__(self, defaults=None, print_include_messages=True):
+    def __init__(self, defaults=None, print_include_messages=True, no_expand_vars=False):
+        self.no_expand_vars = no_expand_vars
         configparser.ConfigParser.__init__(self,
                                    defaults=defaults,
                                    dict_type=collections.OrderedDict,
@@ -52,7 +53,7 @@ class IncludingConfigParser(configparser.ConfigParser):
         s = io.StringIO()
         for line in fp:
             # check for include directives
-            if not getattr(self, 'no_expand_vars', False):
+            if not self.no_expand_vars:
                 line = os.path.expandvars(line)
 
             if line.lower().startswith('%include'):
@@ -95,7 +96,7 @@ class Inifile(IncludingConfigParser):
 
     """
 
-    def __init__(self, filename, defaults=None, override=None, print_include_messages=True):
+    def __init__(self, filename, defaults=None, override=None, print_include_messages=True, no_expand_vars=False):
         u"""Read in a configuration from `filename`.
 
         The `defaults` will be applied if a parameter is not specified in
@@ -110,7 +111,8 @@ class Inifile(IncludingConfigParser):
 
         IncludingConfigParser.__init__(self,
                                        defaults=defaults,
-                                       print_include_messages=print_include_messages)
+                                       print_include_messages=print_include_messages,
+                                       no_expand_vars=no_expand_vars)
 
         # if we are pased a dict, convert it to an inifile
         if isinstance(filename, dict):

--- a/cosmosis/test/campaign.yml
+++ b/cosmosis/test/campaign.yml
@@ -55,3 +55,13 @@ runs:
     submission:
       submit: cat
       walltime: 04:00:00
+
+  - name: env-test-1
+    base: cosmosis/test/example.ini
+    env:
+      TEST : xxx
+
+  - name: env-test-2
+    parent: env-test-1
+    env:
+      TEST : yyy

--- a/cosmosis/test/example.ini
+++ b/cosmosis/test/example.ini
@@ -11,3 +11,4 @@ priors = cosmosis/test/example-priors.ini
 
 [test1]
 file = cosmosis/test/example_module.py
+env_test_var=${TEST}

--- a/cosmosis/test/test_campaign.py
+++ b/cosmosis/test/test_campaign.py
@@ -136,3 +136,10 @@ def test_campaign_functions2():
 
             submit_run("cosmosis/test/campaign.yml", runs["v3"])
             submit_run("cosmosis/test/campaign.yml", runs["v4"])
+
+
+def test_campaign_env():
+    with run_from_source_dir():
+        runs = parse_yaml_run_file("cosmosis/test/campaign.yml")
+    assert runs["env-test-1"]["params"].get("test1", "env_test_var")  == "xxx"
+    assert runs["env-test-2"]["params"].get("test1", "env_test_var")  == "yyy"

--- a/cosmosis/test/test_campaign.py
+++ b/cosmosis/test/test_campaign.py
@@ -1,5 +1,6 @@
 from ..campaign import *
 from ..runtime import Inifile
+import os
 import tempfile
 import yaml
 import contextlib
@@ -139,6 +140,7 @@ def test_campaign_functions2():
 
 
 def test_campaign_env():
+    os.environ["TEST"] = "aaa"
     with run_from_source_dir():
         runs = parse_yaml_run_file("cosmosis/test/campaign.yml")
     assert runs["env-test-1"]["params"].get("test1", "env_test_var")  == "xxx"

--- a/cosmosis/test/test_campaign.py
+++ b/cosmosis/test/test_campaign.py
@@ -71,7 +71,7 @@ def test_campaign_functions():
     with run_from_source_dir():
         runs = parse_yaml_run_file("cosmosis/test/campaign.yml")
 
-        assert len(runs) == 4
+        assert len(runs) == 6
         assert "v1" in runs
         assert runs["v2"]["values"].get("parameters", "p1") == "-2.0 0.0 2.0"
         assert runs["v2"]["priors"].get("parameters", "p2") == "gaussian 0.0 1.0"
@@ -113,7 +113,7 @@ def test_campaign_functions2():
                 print(name)
 
 
-            assert len(runs) == 4
+            assert len(runs) == 6
             assert "v1" in runs
             assert runs["v2"]["values"].get("parameters", "p1") == "-2.0 0.0 2.0"
             assert runs["v2"]["priors"].get("parameters", "p2") == "gaussian 0.0 1.0"


### PR DESCRIPTION
Addresses issue #115 