### PR TITLE
Update nautilus integration to 1.0

### DIFF
--- a/cosmosis/samplers/nautilus/nautilus_sampler.py
+++ b/cosmosis/samplers/nautilus/nautilus_sampler.py
@@ -110,6 +110,7 @@ class NautilusSampler(ParallelSampler):
         self.output.final("neff", sampler.n_eff)
         self.output.final("nsample", len(sampler.posterior()[0]))
         self.output.final("log_z", sampler.log_z)
+        self.output.final("log_z_error", 1.0 / np.sqrt(sampler.n_eff))
         self.converged = True
 
     def is_converged(self):

--- a/cosmosis/samplers/nautilus/nautilus_sampler.py
+++ b/cosmosis/samplers/nautilus/nautilus_sampler.py
@@ -49,6 +49,9 @@ class NautilusSampler(ParallelSampler):
             self.f_live = self.read_ini("f_live", float, 0.01)
             self.n_shell = self.read_ini("n_shell", int, self.n_batch)
             self.n_eff = self.read_ini("n_eff", float, 10000.0)
+            self.n_like_max = self.read_ini("n_like_max", int, -1)
+            if self.n_like_max < 0:
+                self.n_like_max = np.inf
             self.discard_exploration = self.read_ini(
                 "discard_exploration", bool, False)
             self.verbose = self.read_ini("verbose", bool, False)
@@ -92,6 +95,7 @@ class NautilusSampler(ParallelSampler):
         sampler.run(f_live=self.f_live,
                     n_shell=self.n_shell,
                     n_eff=self.n_eff,
+                    n_like_max=self.n_like_max,
                     discard_exploration=self.discard_exploration,
                     verbose=self.verbose)
 
@@ -102,11 +106,10 @@ class NautilusSampler(ParallelSampler):
             logp = logl + prior
             self.output.parameters(sample, extra, logwt, prior, logp)
 
-        self.output.final(
-            "efficiency", sampler.effective_sample_size() / sampler.n_like)
-        self.output.final("neff", sampler.effective_sample_size())
+        self.output.final("efficiency", sampler.n_eff / sampler.n_like)
+        self.output.final("neff", sampler.n_eff)
         self.output.final("nsample", len(sampler.posterior()[0]))
-        self.output.final("log_z", sampler.evidence())
+        self.output.final("log_z", sampler.log_z)
         self.converged = True
 
     def is_converged(self):

--- a/cosmosis/samplers/nautilus/sampler.yaml
+++ b/cosmosis/samplers/nautilus/sampler.yaml
@@ -31,11 +31,11 @@ params:
     n_networks: (integer; default=4) number of neural networks in each network ensemble
     n_batch: (integer; default=100) number of likelihood evaluations that are performed at each step
     seed: (integer, default=-1) random seed, no fixed seed is used if negative
-    random_state: (int; default=-1) random seed, negative values give a random random seed
     filepath: (string; default='None') file used for checkpointing, must have .hdf5 ending
     resume: (bool; default=False) if True, resume from previous run stored in `filepath`
     f_live: (float; default=0.01) live set evidence fraction when exploration phase terminates
     n_shell: (int; default=n_batch) minimum number of points in each shell
     n_eff: (float; default=10000.0) minimum effective sample size
+    n_like_max: (int; default=-1) maximum number of likelihood calls, negative values are interpreted as infinity
     discard_exploration: (bool; default=False) whether to discard points drawn in the exploration phase
     verbose: (bool; default=False) If true, print information about sampler progress

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ mpi4py
 dulwich
 urllib3
 scikit-learn
-nautilus-sampler == 0.6.*
+nautilus-sampler >= 1.0.1

--- a/setup.py
+++ b/setup.py
@@ -191,7 +191,7 @@ requirements = [
     "emcee",
     "dynesty",
     "zeus-mcmc",
-    "nautilus-sampler==0.6.*",
+    "nautilus-sampler>=1.0.0",
     "dulwich",
     "scikit-learn",
     "future",

--- a/setup.py
+++ b/setup.py
@@ -191,7 +191,7 @@ requirements = [
     "emcee",
     "dynesty",
     "zeus-mcmc",
-    "nautilus-sampler>=1.0.0",
+    "nautilus-sampler>=1.0.1",
     "dulwich",
     "scikit-learn",
     "future",


### PR DESCRIPTION
This PR should update the nautilus sampler integration to version 1.0. Currently, `cosmosis` actually only supports nautilus version 0.6. What was the reason for not supporting 0.7? By the way, the updates in 0.7 and 1.0 are fairly minor. Still, it would be good to update cosmosis to nautilus 1.0.