### PR TITLE
Have the rest of the samplers save their best-fit as a hint

### DIFF
--- a/cosmosis/samplers/apriori/apriori_sampler.py
+++ b/cosmosis/samplers/apriori/apriori_sampler.py
@@ -75,6 +75,9 @@ class AprioriSampler(ParallelSampler):
                 #always save the usual text output
                 self.output.parameters(sample, extra, prior, post)
 
+                # this will test to see if the new point is the best so far
+                self.distribution_hints.set_peak(sample, post)
+
         #We only ever run this once, though that could 
         #change if we decide to split up the runs
         self.converged = True

--- a/cosmosis/samplers/dynesty/dynesty_sampler.py
+++ b/cosmosis/samplers/dynesty/dynesty_sampler.py
@@ -81,6 +81,9 @@ class DynestySampler(ParallelSampler):
         results = sampler.results
         results.summary()
 
+        posts = results['blob'][:, 0] + results['logl']
+        self.distribution_hints.set_peak_from_sample(results['samples'], posts)
+
         for sample, logwt, logl, derived in zip(results['samples'],results['logwt'], results['logl'], results['blob']):
             prior = derived[0]
             post = prior + logl

--- a/cosmosis/samplers/dynesty/dynesty_sampler.py
+++ b/cosmosis/samplers/dynesty/dynesty_sampler.py
@@ -87,13 +87,12 @@ class DynestySampler(ParallelSampler):
         for sample, logwt, logl, derived in zip(results['samples'],results['logwt'], results['logl'], results['blob']):
             prior = derived[0]
             post = prior + logl
-            self.output.parameters(sample, logwt, prior, post, derived[1:])
+            self.output.parameters(sample, derived[1:], logwt, prior, post)
 
         self.output.final("efficiency", results['eff'])
         self.output.final("nsample", len(results['samples']))
         self.output.final("log_z", results['logz'][-1])
         self.output.final("log_z_error", results['logzerr'][-1])
-
         self.converged = True
 
 

--- a/cosmosis/samplers/emcee/emcee_sampler.py
+++ b/cosmosis/samplers/emcee/emcee_sampler.py
@@ -131,6 +131,7 @@ class EmceeSampler(ParallelSampler):
 
 
     def output_samples(self, pos, prob, extra_info):
+        self.distribution_hints.set_peak_from_sample(pos, prob)
         for params, post, extra in zip(pos,prob,extra_info):
             prior, extra = extra      
             self.output.parameters(params, extra, prior, post)

--- a/cosmosis/samplers/grid/grid_sampler.py
+++ b/cosmosis/samplers/grid/grid_sampler.py
@@ -117,6 +117,7 @@ class GridSampler(ParallelSampler):
             (prob, prior, extra) = result
             #always save the usual text output
             self.output.parameters(sample, extra, prior, prob)
+            self.distribution_hints.set_peak(sample, prob)
 
     def is_converged(self):
         return self.converged

--- a/cosmosis/samplers/gridmax/gridmax_sampler.py
+++ b/cosmosis/samplers/gridmax/gridmax_sampler.py
@@ -64,6 +64,7 @@ class GridmaxSampler(ParallelSampler):
         #Log the results for posterity
         for p, (pr, po, e) in zip(points, results):
             self.output.parameters(p, e, pr, po)
+            self.distribution_hints.set_peak(p, po)
 
         #And now update our information.
         #We need to find the two points either side
@@ -103,6 +104,8 @@ class GridmaxSampler(ParallelSampler):
             self.maxlike = results[best][0]
 
         logs.overview(f"New best fit L = {posteriors.max()} at {self.pipeline.varied_params[d].name} = {points[best][d]}")
+
+        
 
         #and go on to the next dimension
         self.dimension = (d+1)%self.ndim

--- a/cosmosis/samplers/hints.py
+++ b/cosmosis/samplers/hints.py
@@ -1,18 +1,27 @@
+import numpy as np
 
 class Hints(object):
     def __init__(self):
         self._peak = None
         self._cov = None
+        self._peak_post = None
 
     def has_peak(self):
         return self._peak is not None
-    def set_peak(self, peak):
-        self._peak = peak
+    def set_peak(self, peak, post):
+        if self._peak_post is None or post > self._peak_post:
+            self._peak = peak
+            self._peak_post = post
+
+    def set_peak_from_sample(self, samples, posts):
+        assert len(samples) == len(posts)
+        idx = np.argmax(post)
+        self.set_peak(samples[idx], posts[idx])
     def get_peak(self):
         return self._peak
     def del_peak(self):
         self._peak = None
-
+        self._peak_post = None
     def has_cov(self):
         return self._cov is not None
     def set_cov(self, cov):
@@ -24,6 +33,6 @@ class Hints(object):
     
     def update(self, other):
         if other.has_peak():
-            self.set_peak(other.get_peak())
+            self.set_peak(other.get_peak(), other._peak_post)
         if other.has_cov():
             self.set_cov(other.get_cov())

--- a/cosmosis/samplers/hints.py
+++ b/cosmosis/samplers/hints.py
@@ -15,7 +15,7 @@ class Hints(object):
 
     def set_peak_from_sample(self, samples, posts):
         assert len(samples) == len(posts)
-        idx = np.argmax(post)
+        idx = np.argmax(posts)
         self.set_peak(samples[idx], posts[idx])
     def get_peak(self):
         return self._peak

--- a/cosmosis/samplers/importance/importance_sampler.py
+++ b/cosmosis/samplers/importance/importance_sampler.py
@@ -2,6 +2,7 @@ import itertools
 import collections
 import numpy as np
 from ...runtime import logs
+from ...output import TextColumnOutput, FitsOutput
 
 from .. import ParallelSampler
 
@@ -10,8 +11,8 @@ INI_SECTION = "importance"
 
 
 def task(p):
-    r = importance_pipeline.posterior(p)
-    return r
+    r = importance_pipeline.run_results(p)
+    return r.post, (r.prior, r.extra)
 
 
 class ImportanceSampler(ParallelSampler):
@@ -36,13 +37,20 @@ class ImportanceSampler(ParallelSampler):
 
     def load_samples(self, filename):
         options = {"filename":filename}
-        col_names, cols, metadata, comments, final_metadata = self.output.__class__.load_from_options(options)
+        if filename.endswith(".txt"):
+            output_cls = TextColumnOutput
+        elif filename.endswith(".fits"):
+            output_cls = FitsOutput
+        else:
+            raise ValueError(f"Can only postprocess files in cosmosis text format (.txt) or fits format (.fits), not {filename}")
+            
+        col_names, cols, metadata, comments, final_metadata = output_cls.load_from_options(options)
         # pull out the "post" column first
         col_names = [name.lower() for name in col_names]
-        likelihood_index = col_names.index('post')
-        if likelihood_index<0:
+        posterior_index = col_names.index('post')
+        if posterior_index<0:
             raise ValueError("I could not find a 'post' column in the chain %s"%filename)
-        self.original_likelihoods = cols[0].T[likelihood_index]
+        self.original_posteriors = cols[0].T[posterior_index]
 
         #We split the parameters into three groups:
         #   - ones that we have listed as varying
@@ -91,6 +99,7 @@ class ImportanceSampler(ParallelSampler):
         #P' is the new likelihood.
         self.output.add_column("old_post", float) #This is the old likelihood, log(P)
         self.output.add_column("log_weight", float) #This is the log-weight, the ratio of the likelihoods
+        self.output.add_column("prior", float) #This is the new prior
         self.output.add_column("post", float) #This is the new likelihood, log(P')
 
 
@@ -137,22 +146,23 @@ class ImportanceSampler(ParallelSampler):
             results = list(map(task, samples_chunk))
 
         #Collect together and output the results
-        for i,(sample, (new_like, extra)) in enumerate(zip(samples_chunk, results)):
+        for i,(sample, (new_post, extra)) in enumerate(zip(samples_chunk, results)):
             #We already (may) have some extra values from the pipeline
             #as derived parameters.  Add to those any parameters used in the
             #old pipeline but not the new one
+            new_prior, extra = extra
             extra = list(extra)
             for col in list(self.original_extras.values()):
                 extra.append(col[start+i])
             #and then the old and new likelihoods
-            old_like = self.original_likelihoods[start+i]
+            old_post = self.original_posteriors[start+i]
             if self.add_to_likelihood:
-                new_like += old_like
-            weight = new_like-old_like
-            extra = list(extra) + [old_like,weight,new_like]
+                new_post += old_post
+            weight = new_post - old_post
+            extra = list(extra) + [old_post, weight, new_prior, new_post]
             #and save results
             self.output.parameters(sample, extra)
-            self.distribution_hints.set_peak(sample, new_like)
+            self.distribution_hints.set_peak(sample, new_post)
         #Update the current index
         self.current_index+=self.nstep
 

--- a/cosmosis/samplers/importance/importance_sampler.py
+++ b/cosmosis/samplers/importance/importance_sampler.py
@@ -152,6 +152,7 @@ class ImportanceSampler(ParallelSampler):
             extra = list(extra) + [old_like,weight,new_like]
             #and save results
             self.output.parameters(sample, extra)
+            self.distribution_hints.set_peak(sample, new_like)
         #Update the current index
         self.current_index+=self.nstep
 

--- a/cosmosis/samplers/kombine/kombine_sampler.py
+++ b/cosmosis/samplers/kombine/kombine_sampler.py
@@ -108,6 +108,7 @@ class KombineSampler(ParallelSampler):
 
         for (pos, post, prop, extra_info) in outputs:
             self.output_samples(pos, post, extra_info)
+            self.distribution_hints.set_peak(pos, post)
 
         # Set the starting positions for the next chunk of samples
         # to the last ones for this chunk

--- a/cosmosis/samplers/list/list_sampler.py
+++ b/cosmosis/samplers/list/list_sampler.py
@@ -133,6 +133,7 @@ class ListSampler(ParallelSampler):
                 (prob, (prior,extra)) = result
                 # always save the usual text output
                 self.output.parameters(sample, extra, prior, prob)
+                self.distribution_hints.set_peak(sample, prob)
 
         # We only ever run this once, though that could 
         # change if we decide to split up the runs

--- a/cosmosis/samplers/maxlike/maxlike_sampler.py
+++ b/cosmosis/samplers/maxlike/maxlike_sampler.py
@@ -81,7 +81,7 @@ class MaxlikeSampler(Sampler):
         if self.output_ini:
           self.pipeline.create_ini(opt, self.output_ini)
 
-        self.distribution_hints.set_peak(opt)          
+        self.distribution_hints.set_peak(opt, results.post)
 
         #Also if requested, approximate the covariance matrix with the 
         #inverse of the Hessian matrix.

--- a/cosmosis/samplers/metropolis/metropolis_sampler.py
+++ b/cosmosis/samplers/metropolis/metropolis_sampler.py
@@ -169,6 +169,7 @@ class MetropolisSampler(ParallelSampler):
         if (self.num_samples_post_tuning > 0) or self.save_during_tuning:
             for i, result in enumerate(samples):
                 self.output.parameters(result.vector, result.extra, result.prior, result.post)
+                self.distribution_hints.set_peak(result.vector, result.post)
 
         if self.num_samples_post_tuning <= 0:
             logs.overview("Tuning ends at {} samples\n".format(self.tuning_end))

--- a/cosmosis/samplers/minuit/minuit_sampler.py
+++ b/cosmosis/samplers/minuit/minuit_sampler.py
@@ -111,7 +111,7 @@ class MinuitSampler(ParallelSampler):
             logs.overview("SUCCESS: Minuit has converged!")
             self.save_results(param_vector, param_names, results)
             self.converged = True
-            self.distribution_hints.set_peak(param_vector)
+            self.distribution_hints.set_peak(param_vector, results.post)
 
             if made_cov:
                 cov_matrix = cov_vector.reshape((self.ndim, self.ndim))

--- a/cosmosis/samplers/multinest/multinest_sampler.py
+++ b/cosmosis/samplers/multinest/multinest_sampler.py
@@ -223,6 +223,8 @@ class MultinestSampler(ParallelSampler):
         self.log_z = ins_log_z if self.importance else log_z
         self.log_z_err = log_z_err
         data = np.array([posterior[i] for i in range(n*(self.npar+2))]).reshape((self.npar+2, n))
+
+        self.distribution_hints.set_peak_from_sample(data[:self.ndim], data[self.npar - 1])
         for row in data.T:
             params = row[:self.ndim]
             extra_vals = row[self.ndim:self.npar-2]

--- a/cosmosis/samplers/multinest/multinest_sampler.py
+++ b/cosmosis/samplers/multinest/multinest_sampler.py
@@ -223,8 +223,7 @@ class MultinestSampler(ParallelSampler):
         self.log_z = ins_log_z if self.importance else log_z
         self.log_z_err = log_z_err
         data = np.array([posterior[i] for i in range(n*(self.npar+2))]).reshape((self.npar+2, n))
-
-        self.distribution_hints.set_peak_from_sample(data[:self.ndim], data[self.npar - 1])
+        self.distribution_hints.set_peak_from_sample(data[:self.ndim].T, data[self.npar - 1])
         for row in data.T:
             params = row[:self.ndim]
             extra_vals = row[self.ndim:self.npar-2]

--- a/cosmosis/samplers/nautilus/nautilus_sampler.py
+++ b/cosmosis/samplers/nautilus/nautilus_sampler.py
@@ -99,7 +99,11 @@ class NautilusSampler(ParallelSampler):
                     discard_exploration=self.discard_exploration,
                     verbose=self.verbose)
 
-        for sample, logwt, logl, blob in zip(*sampler.posterior(return_blobs=True)):
+        results = sampler.posterior(return_blobs=True)
+        posts = results[2] + results[3][:, 0]
+        self.distribution_hints.set_peak_from_sample(results[0], posts)
+
+        for sample, logwt, logl, blob in zip(*results):
             blob = np.atleast_1d(blob)
             prior = blob[0]
             extra = blob[1:]

--- a/cosmosis/samplers/pmaxlike/pmaxlike_sampler.py
+++ b/cosmosis/samplers/pmaxlike/pmaxlike_sampler.py
@@ -94,7 +94,7 @@ class PmaxlikeSampler(ParallelSampler):
           self.pipeline.create_ini(opt, self.output_ini)
 
         # If we are coupling to later samplers they can use the peak we have found.
-        self.distribution_hints.set_peak(opt)
+        self.distribution_hints.set_peak(opt, results.post)
 
         #Also if requested, approximate the covariance matrix with the 
         #inverse of the Hessian matrix.

--- a/cosmosis/samplers/pmc/pmc_sampler.py
+++ b/cosmosis/samplers/pmc/pmc_sampler.py
@@ -73,6 +73,7 @@ class PmcSampler(ParallelSampler):
 
         for (vector, post, extra, component, weight) in zip(*results):
             prior, extra = extra
+            self.distribution_hints.set_peak(vector, post)
             self.output.parameters(vector, extra, (component, prior, post, weight))
 
         logs.overview("Done %d iterations, %d samples" % (self.iterations, self.samples))

--- a/cosmosis/samplers/poco/poco_sampler.py
+++ b/cosmosis/samplers/poco/poco_sampler.py
@@ -143,6 +143,7 @@ class PocoMCSampler(ParallelSampler):
             extra = np.atleast_1d(blob)
             prior = logp
             logpost = logl + prior
+            self.distribution_hints.set_peak(sample, logpost)
             self.output.parameters(sample, extra, logw, prior, logpost)
 
         self.output.final("log_z", logz)

--- a/cosmosis/samplers/polychord/polychord_sampler.py
+++ b/cosmosis/samplers/polychord/polychord_sampler.py
@@ -319,6 +319,11 @@ class PolychordSampler(ParallelSampler):
             importance = np.exp(w)
             post = like + prior
             self.output.parameters(params, extra_vals, prior, like, post, importance)
+
+        # priors + likes
+        posts = data[:, self.ndim+self.nderived-1] + data[:, self.ndim+self.nderived+1]
+        self.distribution_hints.set_peak_from_sample(data[:, :self.ndim], posts)
+
         self.output.final("nsample", ndead)
         self.output.flush()
 

--- a/cosmosis/samplers/pymc/pymc_sampler.py
+++ b/cosmosis/samplers/pymc/pymc_sampler.py
@@ -93,6 +93,8 @@ class PymcSampler(ParallelSampler):
                            for param in self.pipeline.varied_params]).T
         likes = -0.5 * self.mcmc.trace('deviance')[:]
 
+        self.distribution_hints.set_peak_from_sample(traces, likes)
+
         for trace, like in zip(traces, likes):
             self.output.parameters(trace, like)
 

--- a/cosmosis/samplers/snake/snake_sampler.py
+++ b/cosmosis/samplers/snake/snake_sampler.py
@@ -35,9 +35,9 @@ class SnakeSampler(ParallelSampler):
             try:
                 x = self.pipeline.denormalize_vector(x)
                 self.output.parameters(x, extra, prior, post)
+                self.distribution_hints.set_peak(x, post)
             except ValueError:
                 logs.noisy("The snake is trying to escape its bounds!")
-
 
 
     def is_converged(self):

--- a/cosmosis/samplers/star/star_sampler.py
+++ b/cosmosis/samplers/star/star_sampler.py
@@ -118,6 +118,7 @@ class StarSampler(ParallelSampler):
             (post, prior, extra) = result
             #always save the usual text output
             self.output.parameters(sample, extra, prior, post)
+            self.distribution_hints.set_peak(sample, post)
 
     def is_converged(self):
         return self.converged

--- a/cosmosis/samplers/zeus/zeus_sampler.py
+++ b/cosmosis/samplers/zeus/zeus_sampler.py
@@ -243,6 +243,7 @@ class ZeusSampler(ParallelSampler):
             for j in range(self.nwalkers):
                 prior, extra = blobs[i, j]
                 self.output.parameters(chain[i, j], extra, prior, post[i, j])
+                self.distribution_hints.set_peak(chain[i, j], post[i, j])
 
         #Set the starting positions for the next chunk of samples
         #to the last ones for this chunk

--- a/cosmosis/test/test_samplers.py
+++ b/cosmosis/test/test_samplers.py
@@ -10,6 +10,10 @@ from astropy.table import Table
 
 minuit_compiled = os.path.exists(Sampler.get_sampler("minuit").libminuit_name)
 
+# our test priors are uniform on [-3, 3] for two
+# parameters, so our expected prior is 1/6 for each of them.
+EXPECTED_LOG_PRIOR = 2*np.log(1./6)
+
 def run(name, check_prior, check_extra=True, can_postprocess=True, do_truth=False, no_extra=False, pp_extra=True, pp_2d=True, **options):
 
     sampler_class = Sampler.registry[name]
@@ -53,7 +57,7 @@ def run(name, check_prior, check_extra=True, can_postprocess=True, do_truth=Fals
     if check_prior:
         pr = np.array(output['prior'])
         # a few samples might be outside the bounds and have zero prior
-        assert np.all((pr==-3.58351893845611)|(pr==-np.inf))
+        assert np.all((pr==EXPECTED_LOG_PRIOR)|(pr==-np.inf))
         # but not all of them
         assert not np.all(pr==-np.inf)
 
@@ -207,6 +211,42 @@ def test_list_sampler():
         assert np.allclose(p2, data[:, 1])
         assert np.allclose(output['PARAMETERS--P3'], p3)
         assert np.allclose(output["post"] - output["prior"], expected_like)
+
+def test_importance_sampler():
+
+    for add_to_likelihood in [True, False]:
+        with tempfile.TemporaryDirectory() as dirname:
+
+            input_chain_filename = os.path.join(dirname, "input_chain.txt")
+            input_chain = TextColumnOutput(input_chain_filename)
+            input_chain.add_column('parameters--p1', float)
+            input_chain.add_column('parameters--p2', float)
+            input_chain.add_column('post', float)
+            nrow = 100
+            original_posteriors = -np.arange(nrow).astype(float)
+            data = np.random.normal(size=(nrow, 2)).clip(-2.99, 2.99)
+            for i in range(nrow):
+                input_chain.parameters(data[i, 0], data[i, 1], original_posteriors[i])
+            input_chain.close()
+            os.system(f"cat {input_chain_filename}")
+
+            output = run("importance", True, can_postprocess=False, input=input_chain_filename, add_to_likelihood=add_to_likelihood)
+            p1 = output['parameters--p1']
+            p2 = output['parameters--p2']
+            p3 = p1 + p2
+            expected_like = -(p1**2 + p2**2)/2.
+            # priors are uniform with range -3 to 3 so normalization should be np.log(1/6)
+            expected_prior = EXPECTED_LOG_PRIOR
+            expected_post = expected_like + expected_prior
+            if add_to_likelihood:
+                expected_post += original_posteriors
+            assert p1.size == 100
+            assert np.allclose(p1, data[:, 0])
+            assert np.allclose(p2, data[:, 1])
+            assert np.allclose(output['PARAMETERS--P3'], p3)
+            assert np.allclose(output["post"], expected_post)
+
+        
 
 @pytest.mark.skipif(sys.version_info < (3,7), reason="pocomc requires python3.6+")
 def test_poco():


### PR DESCRIPTION
Currently only the max-like style samplers save their best-fitting sample as a hint to be used by subsequent samplers, when using sampler chaining mode. This updates the other samplers to do the same.