### PR TITLE
Add output_block option to maxlike sampler

### DIFF
--- a/cosmosis/samplers/maxlike/maxlike_sampler.py
+++ b/cosmosis/samplers/maxlike/maxlike_sampler.py
@@ -35,6 +35,7 @@ class MaxlikeSampler(ParallelSampler):
         self.maxiter = self.read_ini("maxiter", int, 1000)
         self.output_ini = self.read_ini("output_ini", str, "")
         self.output_cov = self.read_ini("output_covmat", str, "")
+        self.output_block = self.read_ini("output_block", str, "")
         self.method = self.read_ini("method",str,"Nelder-Mead")
         self.max_posterior = self.read_ini("max_posterior", bool, False)
         self.repeats = self.read_ini("repeats", int, 1)
@@ -114,6 +115,9 @@ class MaxlikeSampler(ParallelSampler):
 
         if self.output_ini:
             self.pipeline.create_ini(results.vector, self.output_ini)
+        
+        if self.output_block:
+            results.block.save_to_directory(self.output_block)
 
 
         # We only want to update the distribution hints at the very end

--- a/cosmosis/test/test_samplers.py
+++ b/cosmosis/test/test_samplers.py
@@ -167,9 +167,11 @@ def test_maxlike():
     with tempfile.TemporaryDirectory() as dirname:
         output_ini = os.path.join(dirname, "output.ini")
         output_cov = os.path.join(dirname, "output_cov.txt")
-        run('maxlike', True, can_postprocess=False, method="L-BFGS-B", max_posterior=True, output_ini=output_ini, output_covmat=output_cov)
+        output_block = os.path.join(dirname, "output_block")
+        run('maxlike', True, can_postprocess=False, method="L-BFGS-B", max_posterior=True, output_ini=output_ini, output_covmat=output_cov, output_block=output_block)
         assert os.path.exists(output_cov)
         assert os.path.exists(output_ini)
+        assert os.path.isdir(output_block)
         
 
 


### PR DESCRIPTION
Saves the complete datablock for the best-fit overall model