### PR TITLE
handle yaml merge keys

### DIFF
--- a/cosmosis/campaign.py
+++ b/cosmosis/campaign.py
@@ -19,6 +19,8 @@ class UniqueKeyLoader(yaml.SafeLoader):
     def construct_mapping(self, node, deep=False):
         mapping = set()
         for key_node, _ in node.value:
+            if ":merge" in key_node.tag:
+                continue
             key = self.construct_object(key_node, deep=deep)
             if key in mapping:
                 raise ValueError(f"Duplicate {key} key found in YAML.")


### PR DESCRIPTION
This is a small change to support yaml merge keys based on the same gist discussion referenced in the code. This should support constructions such as:
```yaml
runs:
    - name: run1
      ...
      submission: &submit
          template: ...
          time: 12:00:00
    - name: run2
       ....
      submission:
          <<: *submit
          time: 16:00:00
```