### PR TITLE
Avoid serializing the current sample data block in metropolis checkpoints

### DIFF
--- a/cosmosis/samplers/metropolis/metropolis_sampler.py
+++ b/cosmosis/samplers/metropolis/metropolis_sampler.py
@@ -13,7 +13,12 @@ pipeline=None
 METROPOLIS_INI_SECTION = "metropolis"
 
 def posterior(p):
-    return pipeline.run_results(p)
+    results = pipeline.run_results(p)
+    # We never use the block, and it was getting serialized
+    # unnecessarily when writing checkpoints
+    if results is not None:
+        results.block = None
+    return results
 
 
 class MetropolisSampler(ParallelSampler):


### PR DESCRIPTION
Thanks to Nigel Hambly for reporting a symptom of this issue - a metropolis object being saved was storing a reference to a cosmosis datablock. When this was checkpointed a very large amount of data could be saved, and worse it was converted to text format so became extremely large and slow. 

This is a quick and lazy way of avoiding that issue by removing the block.